### PR TITLE
通过WebUIStableDiffusionPipeline.from_pretrained_original_ckpt加载模型因为contronet报错修复

### DIFF
--- a/ppdiffusers/examples/community/webui_stable_diffusion.py
+++ b/ppdiffusers/examples/community/webui_stable_diffusion.py
@@ -378,11 +378,11 @@ class WebUIStableDiffusionPipeline(DiffusionPipeline):
             text_encoder: CLIPTextModel,
             tokenizer: CLIPTokenizer,
             unet: UNet2DConditionModel,
-            controlnet: Union[ControlNetModel, List[ControlNetModel], Tuple[
-                ControlNetModel], MultiControlNetModel],
             scheduler: KarrasDiffusionSchedulers,
             safety_checker: StableDiffusionSafetyChecker,
             feature_extractor: CLIPFeatureExtractor,
+            controlnet: Union[ControlNetModel, List[ControlNetModel], Tuple[
+                ControlNetModel], MultiControlNetModel] = None,
             requires_safety_checker: bool=True, ):
         super().__init__()
 


### PR DESCRIPTION
Update webui_stable_diffusion.py
当使用StableDiffusionPipeline.from_pretrained_original_ckpt()
导入safetensors会因为没有controlnet报错，可以给个默认值None，底层已经处理过None。
已验证可以。