### PR TITLE
fix unidiffuser scheduler for ddim and dpmsolver multistep

### DIFF
--- a/ppdiffusers/ppdiffusers/pipelines/unidiffuser/pipeline_unidiffuser.py
+++ b/ppdiffusers/ppdiffusers/pipelines/unidiffuser/pipeline_unidiffuser.py
@@ -568,7 +568,7 @@ class UniDiffuserPipeline(DiffusionPipeline):
                 noise_pred = self.get_noise_pred(
                     mode,
                     latents,
-                    t * N,
+                    t * N if isinstance(self.scheduler, DPMSolverUniDiffuserScheduler) else t,
                     image_vae_latents,
                     image_clip_latents,
                     prompt_embeds,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
fix unidiffuser scheduler for ddim and dpmsolver multistep
```
import paddle
from paddlenlp.trainer import set_seed
from ppdiffusers import UniDiffuserPipeline, DPMSolverUniDiffuserScheduler, DDIMScheduler, DPMSolverMultistepScheduler

pipe = UniDiffuserPipeline.from_pretrained("thu-ml/unidiffuser")
pipe.scheduler = DPMSolverMultistepScheduler.from_config(pipe.scheduler.config)
# pipe.scheduler = DDIMScheduler.from_config('runwayml/stable-diffusion-v1-5/scheduler')
# pipe.scheduler = DDIMScheduler.from_config("CompVis/ldm-text2im-large-256/scheduler")

set_seed(42)
generator = paddle.Generator().manual_seed(0)

prompt = "an elephant under the sea"
image = pipe(mode="t2i", image=None, prompt=prompt).images[0]
image.save("vis.png")
```

