### PR TITLE
[PPDiffusers] add sd benchmark

### DIFF
--- a/tests/test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
@@ -1,0 +1,13 @@
+model_item=stable_diffusion-098b_pretrain
+model=stable_diffusion
+bs_item=144
+fp_item=bf16
+run_mode=DP
+device_num=N1C1
+max_epochs=200
+num_workers=0
+
+# get data
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/prepare.sh
+# run
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num} ${max_epochs} ${num_workers} 2>&1;

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
@@ -1,0 +1,13 @@
+model_item=stable_diffusion-098b_pretrain
+model=stable_diffusion
+bs_item=96
+fp_item=fp32
+run_mode=DP
+device_num=N1C1
+max_epochs=200
+num_workers=0
+
+# get data
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/prepare.sh
+# run
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num} ${max_epochs} ${num_workers} 2>&1;

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
@@ -1,0 +1,13 @@
+model_item=stable_diffusion-098b_pretrain
+model=stable_diffusion
+bs_item=144
+fp_item=bf16
+run_mode=DP
+device_num=N1C8
+max_epochs=200
+num_workers=0
+
+# get data
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/prepare.sh
+# run
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num} ${max_epochs} ${num_workers} 2>&1;

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
@@ -1,0 +1,13 @@
+model_item=stable_diffusion-098b_pretrain
+model=stable_diffusion
+bs_item=96
+fp_item=fp32
+run_mode=DP
+device_num=N1C8
+max_epochs=200
+num_workers=0
+
+# get data
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/prepare.sh
+# run
+bash ./test_tipc/dygraph/dp/${model}/benchmark_common/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num} ${max_epochs} ${num_workers} 2>&1;

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/prepare.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/prepare.sh
@@ -1,0 +1,23 @@
+rm -rf CompVis-stable-diffusion-v1-4-paddle-init-pd.tar.gz
+rm -rf CompVis-stable-diffusion-v1-4-paddle-init
+rm -rf laion400m_demo_data.tar.gz
+rm -rf data
+
+wget https://bj.bcebos.com/paddlenlp/models/community/CompVis/CompVis-stable-diffusion-v1-4-paddle-init-pd.tar.gz
+tar -zxvf CompVis-stable-diffusion-v1-4-paddle-init-pd.tar.gz
+
+wget https://paddlenlp.bj.bcebos.com/models/community/junnyu/develop/laion400m_demo_data.tar.gz
+tar -zxvf laion400m_demo_data.tar.gz
+
+
+export PYTHONPATH=$(dirname "$PWD"):$PYTHONPATH
+python -m pip install --upgrade pip -i https://mirror.baidu.com/pypi/simple
+python -m pip install einops -i https://mirror.baidu.com/pypi/simple
+python -m pip install -r ../requirements.txt
+python -m pip install --upgrade paddlenlp pybind11 regex sentencepiece tqdm visualdl attrdict easydict pyyaml -i https://mirror.baidu.com/pypi/simple
+
+# uninstall ppdiffusers and install develop paddlemix
+python -m pip uninstall -y ppdiffusers
+python -m pip install -e ../
+python -m pip list
+cd -

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
@@ -26,7 +26,7 @@ function _set_params(){
  
     model_repo="PaddleMIX"          # (必选) 模型套件的名字
     speed_unit="sample/sec"         # (必选)速度指标单位
-    skip_steps=2                  # (必选)解析日志，跳过模型前几个性能不稳定的step
+    skip_steps=4                  # (必选)解析日志，跳过模型前几个性能不稳定的step
     keyword="ips:"                 # (必选)解析日志，筛选出性能数据所在行的关键字
     convergence_key="loss:"        # (可选)解析日志，筛选出收敛数据所在行的关键字 如：convergence_key="loss:"
     max_iter=${6:-"500"}                 # （可选）需保证模型执行时间在5分钟内，需要修改代码提前中断的直接提PR 合入套件  或是max_epoch
@@ -109,7 +109,7 @@ function _train(){
             train_cmd="python -u ${train_cmd}" 
         else
             rm -rf ./mylog   # 注意执行前删掉log目录
-            train_cmd="python -m -u paddle.distributed.launch --log_dir=./mylog --gpus=$CUDA_VISIBLE_DEVICES \
+            train_cmd="python -u -m paddle.distributed.launch --log_dir=./mylog --gpus=$CUDA_VISIBLE_DEVICES \
                   ${train_cmd}" 
         fi
         ;;

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
@@ -118,7 +118,7 @@ function _train(){
     esac
     
     echo "train_cmd: ${train_cmd}  log_file: ${log_file}"
-    timeout 15m ${train_cmd} > ${log_file} 2>&1
+    timeout 30m ${train_cmd} > ${log_file} 2>&1
     if [ $? -ne 0 ];then
         echo -e "${model_name}, FAIL"
     else

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Test training benchmark for a model.
+# Usage：bash benchmark/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num}
+function _set_params(){
+    model_item=${1:-"stable_diffusion-098b_pretrain"}   # (必选) 模型 item |fastscnn|segformer_b0| ocrnet_hrnetw48
+    base_batch_size=${2:-"2"}       # (必选) 如果是静态图单进程，则表示每张卡上的BS，需在训练时*卡数
+    fp_item=${3:-"fp32"}            # (必选) fp32|fp16|bf16
+    run_mode=${4:-"DP"}             # (必选) MP模型并行|DP数据并行|PP流水线并行|混合并行DP1-MP1-PP1|DP1-MP4-PP1
+    device_num=${5:-"N1C1"}         # (必选) 使用的卡数量，N1C1|N1C8|N4C32 （4机32卡）
+    profiling=${PROFILING:-"false"}      # (必选) Profiling  开关，默认关闭，通过全局变量传递
+ 
+    model_repo="PaddleMIX"          # (必选) 模型套件的名字
+    speed_unit="sample/sec"         # (必选)速度指标单位
+    skip_steps=2                  # (必选)解析日志，跳过模型前几个性能不稳定的step
+    keyword="ips:"                 # (必选)解析日志，筛选出性能数据所在行的关键字
+    convergence_key="loss:"        # (可选)解析日志，筛选出收敛数据所在行的关键字 如：convergence_key="loss:"
+    max_iter=${6:-"500"}                 # （可选）需保证模型执行时间在5分钟内，需要修改代码提前中断的直接提PR 合入套件  或是max_epoch
+    num_workers=${7:-"5"}                # (可选)
+    is_large_model=False           # (可选)普通模型默认为False，如果添加大模型且只取一条ips设置为True
+
+    # 以下为通用执行命令，无特殊可不用修改
+    model_name=${model_item}_bs${base_batch_size}_${fp_item}_${run_mode}  # (必填) 且格式不要改动,与竞品名称对齐
+    device=${CUDA_VISIBLE_DEVICES//,/ }
+    arr=(${device})
+    num_gpu_devices=${#arr[*]}
+    run_log_path=${TRAIN_LOG_DIR:-$(pwd)}  # （必填） TRAIN_LOG_DIR  benchmark框架设置该参数为全局变量
+    profiling_log_path=${PROFILING_LOG_DIR:-$(pwd)}  # （必填） PROFILING_LOG_DIR benchmark框架设置该参数为全局变量
+    speed_log_path=${LOG_PATH_INDEX_DIR:-$(pwd)}
+
+    train_log_file=${run_log_path}/${model_repo}_${model_name}_${device_num}_log
+    profiling_log_file=${profiling_log_path}/${model_repo}_${model_name}_${device_num}_profiling
+    speed_log_file=${speed_log_path}/${model_repo}_${model_name}_${device_num}_speed
+}
+
+function _train(){
+    batch_size=${base_batch_size}  # 如果模型跑多卡单进程时,请在_train函数中计算出多卡需要的bs
+    echo "current CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}, model_name=${model_name}, device_num=${device_num}, is profiling=${profiling}"
+    if [ ${profiling} = "true" ];then
+            add_options="--profiler_options=\"batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile\""
+            log_file=${profiling_log_file}
+        else
+            add_options=""
+            log_file=${train_log_file}
+    fi
+    if [ ${fp_item} = "fp16" ]; then
+        use_fp16_cmd="--fp16 True"
+    fi
+    if [ ${fp_item} = "bf16" ]; then
+        use_fp16_cmd="--bf16 True --fp16_opt_level O2"
+    fi
+    rm -rf ./outputs
+
+    export FLAG_USE_EMA=0
+    export FLAG_BENCHMARK=1
+    export FLAG_RECOMPUTE=1
+    export FLAG_XFORMERS=1
+    # use fused linear
+    export FLAG_FUSED_LINEAR=1
+
+    train_cmd="../ppdiffusers/examples/stable_diffusion/train_txt2img_laion400m_trainer.py \
+            --do_train \
+            --output_dir ./outputs \
+            --per_device_train_batch_size ${batch_size} \
+            --gradient_accumulation_steps 1 \
+            --learning_rate 1e-4 \
+            --weight_decay 0.01 \
+            --max_steps ${max_iter} \
+            --lr_scheduler_type "constant" \
+            --warmup_steps 0 \
+            --image_logging_steps 1000 \
+            --logging_steps 5 \
+            --resolution 256 \
+            --save_steps 10000 \
+            --save_total_limit 20 \
+            --seed 23 \
+            --dataloader_num_workers 8 \
+            --pretrained_model_name_or_path ./CompVis-stable-diffusion-v1-4-paddle-init \
+            --file_list ./data/filelist/train.filelist.list \
+            --model_max_length 77 \
+            --max_grad_norm -1 \
+            --disable_tqdm True \
+            --overwrite_output_dir \
+            ${use_fp16_cmd}
+        "
+
+
+    # 以下为通用执行命令，无特殊可不用修改
+    case ${run_mode} in
+    DP) if [[ ${device_num} = "N1C1" ]];then
+            echo "run ${run_mode} "
+            train_cmd="python -u ${train_cmd}" 
+        else
+            rm -rf ./mylog   # 注意执行前删掉log目录
+            train_cmd="python -m -u paddle.distributed.launch --log_dir=./mylog --gpus=$CUDA_VISIBLE_DEVICES \
+                  ${train_cmd}" 
+        fi
+        ;;
+    DP1-MP1-PP1)  echo "run run_mode: DP1-MP1-PP1" ;;
+    *) echo "choose run_mode "; exit 1;
+    esac
+    
+    echo "train_cmd: ${train_cmd}  log_file: ${log_file}"
+    timeout 15m ${train_cmd} > ${log_file} 2>&1
+    if [ $? -ne 0 ];then
+        echo -e "${model_name}, FAIL"
+    else
+        echo -e "${model_name}, SUCCESS"
+    fi
+    # kill -9 `ps -ef|grep 'python'|awk '{print $2}'`
+
+    if [ ${device_num} != "N1C1" -a -d mylog ]; then
+        rm ${log_file}
+        cp mylog/workerlog.0 ${log_file}
+    fi
+}
+
+source ${BENCHMARK_ROOT}/scripts/run_model.sh   # 在该脚本中会对符合benchmark规范的log使用analysis.py 脚本进行性能数据解析;如果不联调只想要产出训练log可以注掉本行,提交时需打开
+_set_params $@
+# _train       # 如果只产出训练log,不解析,可取消注释
+_run     # 该函数在run_model.sh中,执行时会调用_train; 如果不联调只产出训练log可以注掉本行,提交时需打开

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/run_benchmark.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Test training benchmark for a model.
 # Usage：bash benchmark/run_benchmark.sh ${model_item} ${bs_item} ${fp_item} ${run_mode} ${device_num}
 function _set_params(){
@@ -46,8 +60,11 @@ function _train(){
     if [ ${fp_item} = "fp16" ]; then
         use_fp16_cmd="--fp16 True"
     fi
+
+    FUSED=False
     if [ ${fp_item} = "bf16" ]; then
         use_fp16_cmd="--bf16 True --fp16_opt_level O2"
+        FUSED=True
     fi
     rm -rf ./outputs
 
@@ -55,8 +72,8 @@ function _train(){
     export FLAG_BENCHMARK=1
     export FLAG_RECOMPUTE=1
     export FLAG_XFORMERS=1
-    # use fused linear
-    export FLAG_FUSED_LINEAR=1
+    # use fused linear in amp o2 level
+    export FLAG_FUSED_LINEAR=${FUSED}
 
     train_cmd="../ppdiffusers/examples/stable_diffusion/train_txt2img_laion400m_trainer.py \
             --do_train \


### PR DESCRIPTION
```python
git clone https://github.com/PaddlePaddle/PaddleMIX
cd PaddleMIX/tests
wget xxxxxxx/tools.tar.gz  && tar xvf tools.tar.gz && export BENCHMARK_ROOT=$PWD/tools/ 

# 单机单卡
export CUDA_VISIBLE_DEVICES=0

# fp32
export script_path=test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
bash $script_path

# bf16 o2
export script_path=test_tipc/dygraph/dp/stable_diffusion/N1C1/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
bash $script_path

# 单机八卡
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

# fp32
export script_path=test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs96_fp32_DP.sh
bash $script_path

# bf16 o2
export script_path=test_tipc/dygraph/dp/stable_diffusion/N1C8/stable_diffusion-098b_pretrain_bs144_bf16_DP.sh
bash $script_path
```

![image](https://github.com/PaddlePaddle/PaddleMIX/assets/50394665/2bd7c043-c9d1-44d9-a03f-b6e156efd9bb)
