### PR TITLE
add MixPretrainedModel for PaddleMIX

### DIFF
--- a/paddlemix/models/blip2/Qformer.py
+++ b/paddlemix/models/blip2/Qformer.py
@@ -32,7 +32,8 @@ from paddlenlp.transformers.model_outputs import (
     CausalLMOutputWithCrossAttentions,
     MaskedLMOutput,
 )
-from paddlenlp.transformers.model_utils import PretrainedModel
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 
 class CrossEntropyLoss(nn.Layer):
@@ -727,7 +728,7 @@ class BertOnlyMLMHead(nn.Layer):
         return prediction_scores
 
 
-class BertPreTrainedModel(PretrainedModel):
+class BertPreTrainedModel(MixPretrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
     models.

--- a/paddlemix/models/blip2/modeling.py
+++ b/paddlemix/models/blip2/modeling.py
@@ -22,7 +22,6 @@ import paddle.nn as nn
 from paddlenlp.transformers import AutoTokenizer
 from paddlenlp.transformers.llama.modeling import LlamaForCausalLM
 from paddlenlp.transformers.model_outputs import ModelOutput
-from paddlenlp.transformers.model_utils import PretrainedModel
 from paddlenlp.transformers.opt.modeling import OPTForCausalLM
 from paddlenlp.transformers.t5.modeling import T5ForConditionalGeneration
 
@@ -33,6 +32,7 @@ from paddlemix.models.blip2.modeling_utils import (
     masked_fill,
 )
 from paddlemix.models.blip2.Qformer import BertLMHeadModel
+from paddlemix.models.model_utils import MixPretrainedModel
 from paddlemix.utils.log import logger
 
 from .configuration import Blip2Config
@@ -99,7 +99,7 @@ class Blip2ForStage1ModelOutput(Blip2ForConditionalGenerationModelOutput):
     loss_lm: Optional[Tuple[paddle.Tensor]] = None
 
 
-class Blip2PretrainedModel(PretrainedModel):
+class Blip2PretrainedModel(MixPretrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
     models.

--- a/paddlemix/models/evaclip/eva_clip_model.py
+++ b/paddlemix/models/evaclip/eva_clip_model.py
@@ -24,8 +24,9 @@ from typing import Union
 
 import numpy as np
 from paddlenlp.transformers.configuration_utils import PretrainedConfig
-from paddlenlp.transformers.model_utils import PretrainedModel
-from paddlenlp.utils.log import logger
+
+from paddlemix.models.model_utils import MixPretrainedModel
+from paddlemix.utils.log import logger
 
 from .eva_text_model import EVATextTransformer, EVATextTransformerConfig
 from .eva_vit_model import EVAVisionTransformer, EVAVisionTransformerConfig
@@ -98,9 +99,9 @@ class EVACLIPConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-class EVACLIPPretrainedModel(PretrainedModel):
+class EVACLIPPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`paddlemix.models.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"

--- a/paddlemix/models/evaclip/eva_text_model.py
+++ b/paddlemix/models/evaclip/eva_text_model.py
@@ -44,8 +44,9 @@ except:
     print("Warning: import memory_efficient_attention error")
 
 from paddlenlp.transformers.configuration_utils import PretrainedConfig
-from paddlenlp.transformers.model_utils import PretrainedModel
-from paddlenlp.utils.log import logger
+
+from paddlemix.models.model_utils import MixPretrainedModel
+from paddlemix.utils.log import logger
 
 
 def _convert_attention_mask(attn_mask, dtype):
@@ -402,7 +403,7 @@ class PatchDropout(paddle.nn.Layer):
         x = x[batch_indices, patch_indices_keep]
         if self.exclude_first_token:
             x = paddle.concat(x=(cls_tokens, x), axis=1)
-        if self.training and os.getenv('RoPE') == '1':
+        if self.training and os.getenv("RoPE") == "1":
             return x, patch_indices_keep
         return x
 
@@ -1069,9 +1070,9 @@ class EVATextTransformerConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-class EVATextTransformerPretrainedModel(PretrainedModel):
+class EVATextTransformerPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`paddlemix.models.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"

--- a/paddlemix/models/evaclip/eva_vit_model.py
+++ b/paddlemix/models/evaclip/eva_vit_model.py
@@ -33,8 +33,9 @@ from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
 from paddle.incubate.nn.memory_efficient_attention import memory_efficient_attention
 from paddlenlp.transformers.configuration_utils import PretrainedConfig
-from paddlenlp.transformers.model_utils import PretrainedModel
-from paddlenlp.utils.log import logger
+
+from paddlemix.models.model_utils import MixPretrainedModel
+from paddlemix.utils.log import logger
 
 from .utils import to_2tuple, trunc_normal_
 
@@ -590,9 +591,9 @@ class EVAVisionTransformerConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-class EVAVisionTransformerPretrainedModel(PretrainedModel):
+class EVAVisionTransformerPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`paddlemix.models.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"

--- a/paddlemix/models/groundingdino/backbone/swin_transformer.py
+++ b/paddlemix/models/groundingdino/backbone/swin_transformer.py
@@ -28,7 +28,9 @@ from ..layers import DropPath, to_2tuple
 trunc_normal_ = nn.initializer.TruncatedNormal(std=0.02)
 
 from paddlenlp.transformers.configuration_utils import PretrainedConfig
-from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
+from paddlenlp.transformers.model_utils import register_base_model
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 """ swin_transformer model configuration"""
 __all__ = ["SwinTransformerConfig"]
@@ -99,9 +101,9 @@ class SwinTransformerConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-class SwinTransformerPretrainedModel(PretrainedModel):
+class SwinTransformerPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`paddlemix.models.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"

--- a/paddlemix/models/groundingdino/modeling.py
+++ b/paddlemix/models/groundingdino/modeling.py
@@ -19,8 +19,10 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddlenlp.transformers import BertModel, RobertaModel
-from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
+from paddlenlp.transformers.model_utils import register_base_model
 from paddlenlp.utils.initializer import constant_, xavier_uniform_
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 from .backbone import build_backbone
 from .bertwarper import BertModelWarper
@@ -34,9 +36,9 @@ __all__ = [
 ]
 
 
-class GroundingDinoPretrainedModel(PretrainedModel):
+class GroundingDinoPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`paddlemix.models.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"

--- a/paddlemix/models/imagebind/modeling.py
+++ b/paddlemix/models/imagebind/modeling.py
@@ -16,7 +16,9 @@ from functools import partial
 from types import SimpleNamespace
 
 import paddle
-from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
+from paddlenlp.transformers.model_utils import register_base_model
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 from .configuration import ImageBindConfig
 from .helpers import (
@@ -52,9 +54,9 @@ __all__ = [
 ]
 
 
-class ImageBindPretrainedModel(PretrainedModel):
+class ImageBindPretrainedModel(MixPretrainedModel):
     """
-    See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
+    See :class:`~paddlenlp.transformers.model_utils.MixPretrainedModel` for more details.
     """
 
     model_config_file = "config.json"
@@ -536,10 +538,8 @@ class ImageBindModel(ImageBindPretrainedModel):
                 modality_value = self.modality_trunks[modality_key](**trunk_inputs)
                 modality_value = self.modality_heads[modality_key](modality_value, **head_inputs)
                 modality_value = self.modality_postprocessors[modality_key](modality_value)
-                if modality_key=='audio' or modality_key=='depth' or modality_key=='thermal':
-                    modality_value = self.modality_postprocessors[modality_key](
-                        modality_value
-                    )
+                if modality_key == "audio" or modality_key == "depth" or modality_key == "thermal":
+                    modality_value = self.modality_postprocessors[modality_key](modality_value)
                 if reduce_list:
                     modality_value = modality_value.reshape(B, S, -1)
                     modality_value = modality_value.mean(axis=1)

--- a/paddlemix/models/minigpt4/modeling.py
+++ b/paddlemix/models/minigpt4/modeling.py
@@ -30,11 +30,12 @@ from paddlenlp.transformers.model_outputs import (
     ModelOutput,
 )
 from paddlenlp.transformers.model_utils import (
-    PretrainedModel,
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 from ...activations import ACT2FN
 from ...utils.initializer import normal_, ones_, zeros_
@@ -119,7 +120,7 @@ class MiniGPT4ForConditionalGenerationModelOutput(ModelOutput):
         )
 
 
-class MiniGPT4PretrainedModel(PretrainedModel):
+class MiniGPT4PretrainedModel(MixPretrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
     models.

--- a/paddlemix/models/model_utils.py
+++ b/paddlemix/models/model_utils.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import os
+import re
+import warnings
+from typing import List, Optional, Tuple
+
+import numpy as np
+import paddle
+from paddlenlp.transformers import PretrainedModel
+from tqdm.auto import tqdm
+
+from paddlemix.utils import device_guard, paddlemix_load
+from paddlemix.utils.env import MODEL_HOME
+from paddlemix.utils.log import logger
+
+
+def resolve_cache_dir(pretrained_model_name_or_path: str, cache_dir: Optional[str] = None) -> str:
+    """resolve cache dir for PretrainedModel and PretrainedConfig
+
+    Args:
+        pretrained_model_name_or_path (str): the name or path of pretrained model
+        cache_dir (str): cache_dir for models
+    """
+    if os.path.isdir(pretrained_model_name_or_path):
+        return pretrained_model_name_or_path
+
+    if cache_dir is not None:
+        # since model_clas.from_pretrained calls config_clas.from_pretrained, the model_name may get appended twice
+        if cache_dir.endswith(pretrained_model_name_or_path):
+            return cache_dir
+        else:
+            return os.path.join(cache_dir, pretrained_model_name_or_path)
+    return os.path.join(MODEL_HOME, pretrained_model_name_or_path)
+
+
+def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
+    # torch will cast dtype in load_state_dict, but paddle strictly check dtype
+    _convert_state_dict_dtype_and_shape(state_dict, model_to_load)
+
+    error_msgs = []
+
+    if len(start_prefix) > 0:
+        for key in list(state_dict.keys()):
+            if key.startswith(start_prefix):
+                state_dict[key.replace(start_prefix, "")] = state_dict.pop(key)
+
+    # TODO: add return status to state_dict
+    with warnings.catch_warnings(record=True) as w:
+        warnings.resetwarnings()
+        # paddlenlp hold  missing_keys , just ignore not found warnings.
+        warnings.filterwarnings("ignore", message=r".*is not found in the provided dict.*")
+        model_to_load.set_state_dict(state_dict)
+        error_msgs.extend([str(x.message) for x in w])
+
+    del state_dict
+
+    return error_msgs
+
+
+def _convert_state_dict_dtype_and_shape(state_dict, model_to_load):
+    # convert the dtype of state dict
+    def is_0d_or_1d(tensor):
+        return len(tensor.shape) == 0 or list(tensor.shape) == [1]
+
+    for key, value in model_to_load.state_dict().items():
+        if key in state_dict:
+            if isinstance(state_dict[key], np.ndarray):
+                raise ValueError(
+                    "convert_state_dict_dtype expected paddle.Tensor not numpy.ndarray, plase convert numpy.ndarray to paddle.Tensor"
+                )
+            if state_dict[key].is_floating_point() and state_dict[key].dtype != value.dtype:
+                state_dict[key] = paddle.cast(state_dict.pop(key), value.dtype)
+
+            # unified 0d and 1d tensor
+            if is_0d_or_1d(value) and is_0d_or_1d(state_dict[key]):
+                if list(value.shape) != list(state_dict[key].shape):
+                    state_dict[key] = paddle.reshape(state_dict.pop(key), value.shape)
+
+
+def _load_state_dict_into_meta_model(
+    model,
+    state_dict,
+    loaded_state_dict_keys,  # left for now but could be removed, see below
+    start_prefix,
+    expected_keys,
+    dtype=None,
+    is_safetensors=False,
+    keep_in_fp32_modules=None,
+):
+    """
+    This is somewhat similar to `_load_state_dict_into_model`, but deals with a model that has some or all of its
+    params on a `meta` device. It replaces the model params with the data from the `state_dict`, while moving the
+    params back to the normal device, but only for `loaded_state_dict_keys`.
+
+    `start_prefix` is used for models which insert their name into model keys, e.g. `bert` in
+    `bert.pooler.dense.weight`
+
+    """
+    from paddle.common_ops_import import convert_np_dtype_to_dtype_
+
+    dtype = convert_np_dtype_to_dtype_(dtype)
+    error_msgs = []
+
+    for param_name, param in state_dict.items():
+        # First part of the test is always true as loaded_state_dict_keys always contains state_dict keys.
+        if param_name not in loaded_state_dict_keys or param_name not in expected_keys:
+            continue
+
+        if param_name.startswith(start_prefix):
+            param_name = param_name[len(start_prefix) :]
+
+        if param.place != paddle.framework._current_expected_place():
+            param = param._copy_to(paddle.framework._current_expected_place(), False)
+
+        # # We convert floating dtypes to the `dtype` passed. We want to keep the buffers/params
+        # # in int/uint/bool and not cast them.
+        if dtype is not None and paddle.is_floating_point(param):
+            if (
+                keep_in_fp32_modules is not None
+                and any(module_to_keep_in_fp32 in param_name for module_to_keep_in_fp32 in keep_in_fp32_modules)
+                and dtype == paddle.float16
+            ):
+                param = param.astype(dtype=paddle.float32)
+            else:
+                param = param.astype(dtype=dtype)
+
+        if dtype is None:
+            old_param = model
+            splits = param_name.split(".")
+            for split in splits:
+                old_param = getattr(old_param, split)
+                if old_param is None:
+                    break
+
+            if old_param is not None:
+                param = param.astype(dtype=old_param.dtype)
+
+        with paddle.no_grad():
+            model.state_dict()[param_name].get_tensor()._share_data_with(param.value().get_tensor())
+            param.value().get_tensor()._clear()
+
+    return error_msgs
+
+
+class MixPretrainedModel(PretrainedModel):
+    def __init__(self, *args, **kwargs):
+        super(MixPretrainedModel, self).__init__(*args, **kwargs)
+
+    def get_expected_keys(self, model_state_dict):
+        # override when model needs to load different pretrain model at different stages, such as BLIP-2
+        return list(model_state_dict.keys())
+
+    def refine_state_dict(self, state_dict):
+        # preprocess the weight loaded here, such as interpolatation
+        pass
+
+    def load_pretrained(
+        self,
+        pretrained_model_name_or_path=None,
+        state_dict=None,
+        ignore_mismatched_sizes=False,
+        low_cpu_mem_usage=False,
+        dtype=None,
+        cache_dir=None,
+        subfolder="",
+        variant=None,
+        *args,
+        **kwargs,
+    ) -> Tuple[List[str]]:
+        """load the state_dict into model, and do the following things:
+
+            * check the
+
+        Args:
+            model (PretrainedModel): the pretrained model instance
+            state_dict (Dict[str, Tensor]): the model state dict data
+            ignore_mismatched_sizes (bool, optional): whether ignore error when tensor size mismatched. Defaults to False.
+            dtype (_type_, optional): the dtype of model state dict. Defaults to None.
+
+        Returns:
+            Tuple[List[str]]: _description_
+        """
+        if pretrained_model_name_or_path is None and state_dict is None:
+            ValueError("Either pretrained_model_name_or_path or state_dict should be set.")
+
+        cache_dir = resolve_cache_dir(pretrained_model_name_or_path, cache_dir)
+
+        # Keep in fp32 modules
+        keep_in_fp32_modules = None
+        use_keep_in_fp32_modules = False
+
+        # resolve model_weight file
+        resolved_archive_file, sharded_metadata, is_sharded = self._resolve_model_file_path(
+            pretrained_model_name_or_path,
+            cache_dir=cache_dir,
+            subfolder=subfolder,
+            variant=variant,
+        )
+
+        # load pt weights early so that we know which dtype to init the model under
+        if not is_sharded and state_dict is None:
+            # Time to load the checkpoint
+            # loading non-sharded ckpt from the state dict
+            if self.config.tensor_parallel_degree > 1 and resolved_archive_file.endswith("model_state.pdparams"):
+                state_dict = self.convert_tensor_parallel(resolved_archive_file, self.config)
+            else:
+                state_dict = paddlemix_load(resolved_archive_file)
+
+            self.refine_state_dict(state_dict)
+
+            logger.info("Loaded weights file from disk, setting weights to model.")
+
+        # Check if `_keep_in_fp32_modules` is not None
+        use_keep_in_fp32_modules = (self._keep_in_fp32_modules is not None) and dtype == "float16"
+
+        if is_sharded:
+            loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
+        else:
+            loaded_state_dict_keys = [k for k in state_dict.keys()]
+
+        if low_cpu_mem_usage:  # or use_keep_in_fp32_modules:
+            state_dict = None
+
+        # will only support load paddle.Tensor to model.
+        if state_dict is not None:
+            for k in list(state_dict.keys()):
+                if not isinstance(state_dict[k], paddle.Tensor):
+                    with device_guard():
+                        state_dict[k] = paddle.Tensor(state_dict.pop(k), zero_copy=True)
+
+        if use_keep_in_fp32_modules:
+            # low_cpu_mem_usage = True
+            keep_in_fp32_modules = self._keep_in_fp32_modules
+        else:
+            keep_in_fp32_modules = []
+
+        # load_pretrained_model
+        is_safetensors = False
+
+        model_state_dict = self.state_dict()
+
+        expected_keys = self.get_expected_keys(model_state_dict)
+
+        prefix = self.base_model_prefix
+
+        if len(prefix) > 0:
+            has_prefix_module = any(s.startswith(prefix) for s in loaded_state_dict_keys)
+            expects_prefix_module = any(s.startswith(prefix) for s in expected_keys)
+        else:
+            has_prefix_module = False
+            expects_prefix_module = False
+
+        # key re-naming operations are never done on the keys
+        # that are loaded, but always on the keys of the newly initialized model
+        remove_prefix_from_model = not has_prefix_module and expects_prefix_module
+        add_prefix_to_model = has_prefix_module and not expects_prefix_module
+
+        if remove_prefix_from_model:
+            _prefix = f"{prefix}."
+            expected_keys_not_prefixed = [s for s in expected_keys if not s.startswith(_prefix)]
+            expected_keys = [s[len(_prefix) :] if s.startswith(_prefix) else s for s in expected_keys]
+        elif add_prefix_to_model:
+            expected_keys = [".".join([prefix, s]) for s in expected_keys]
+
+        missing_keys = list(set(expected_keys) - set(loaded_state_dict_keys))
+        unexpected_keys = list(set(loaded_state_dict_keys) - set(expected_keys))
+
+        # Some models may have keys that are not in the state by design, removing them before needlessly warning
+        # the user.
+        if self._keys_to_ignore_on_load_missing is not None:
+            for pat in self._keys_to_ignore_on_load_missing:
+                missing_keys = [k for k in missing_keys if re.search(pat, k) is None]
+
+        if self._keys_to_ignore_on_load_unexpected is not None:
+            for pat in self._keys_to_ignore_on_load_unexpected:
+                unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
+
+        # Set some modules to fp32 if any
+        if keep_in_fp32_modules is not None:
+            for name, param in self.named_parameters():
+                if any(module_to_keep_in_fp32 in name for module_to_keep_in_fp32 in keep_in_fp32_modules):
+                    param = param.to(dtype=paddle.float32)
+
+        # Make sure we are able to load base models as well as derived models (with heads)
+        start_prefix = ""
+        model_to_load = self
+        if len(self.base_model_prefix) > 0 and not hasattr(self, self.base_model_prefix) and has_prefix_module:
+            start_prefix = self.base_model_prefix + "."
+        if len(self.base_model_prefix) > 0 and hasattr(self, self.base_model_prefix) and not has_prefix_module:
+            model_to_load = getattr(self, self.base_model_prefix)
+            base_model_expected_keys = list(model_to_load.state_dict().keys())
+            if any(
+                key in expected_keys_not_prefixed and key not in base_model_expected_keys
+                for key in loaded_state_dict_keys
+            ):
+                raise ValueError(
+                    "The state dictionary of the model you are trying to load is corrupted. Are you sure it was "
+                    "properly saved?"
+                )
+
+        def _find_mismatched_keys(
+            state_dict,
+            model_state_dict,
+            loaded_keys,
+            add_prefix_to_model,
+            remove_prefix_from_model,
+            ignore_mismatched_sizes,
+        ):
+            mismatched_keys = []
+            if ignore_mismatched_sizes:
+                for checkpoint_key in loaded_keys:
+                    # If the checkpoint is sharded, we may not have the key here.
+                    if checkpoint_key not in state_dict:
+                        continue
+                    model_key = checkpoint_key
+                    if remove_prefix_from_model:
+                        # The model key starts with `prefix` but `checkpoint_key` doesn't so we add it.
+                        model_key = f"{prefix}.{checkpoint_key}"
+                    elif add_prefix_to_model:
+                        # The model key doesn't start with `prefix` but `checkpoint_key` does so we remove it.
+                        model_key = ".".join(checkpoint_key.split(".")[1:])
+
+                    if (
+                        model_key in model_state_dict
+                        and state_dict[checkpoint_key].shape != model_state_dict[model_key].shape
+                    ):
+                        mismatched_keys.append(
+                            (checkpoint_key, state_dict[checkpoint_key].shape, model_state_dict[model_key].shape)
+                        )
+                        del state_dict[checkpoint_key]
+            return mismatched_keys
+
+        if state_dict is not None:
+            # DONT Hold tensor parallel here, only hold afer load state dict.
+            # Whole checkpoint
+            # For model parallel if FastGeneration
+            # To avoid recursive import temporarily.
+            import paddlenlp.ops.fast_transformer.transformer.decoding as ft_decoding
+
+            state_dict = ft_decoding.get_ft_para_conf().fit_partial_model(model_to_load, state_dict)
+
+            mismatched_keys = _find_mismatched_keys(
+                state_dict,
+                model_state_dict,
+                loaded_state_dict_keys,
+                add_prefix_to_model,
+                remove_prefix_from_model,
+                ignore_mismatched_sizes,
+            )
+            error_msgs = _load_state_dict_into_model(model_to_load, state_dict, start_prefix)
+        else:
+            # Sharded checkpoint or whole but low_cpu_mem_usage==True
+
+            # This should always be a list but, just to be sure.
+            if not isinstance(resolved_archive_file, list):
+                resolved_archive_file = [resolved_archive_file]
+
+            error_msgs = []
+            mismatched_keys = []
+
+            if len(resolved_archive_file) > 1:
+                resolved_archive_file = tqdm(resolved_archive_file, desc="Loading checkpoint shards")
+
+            for shard_file in resolved_archive_file:
+                pre_tensor_parallel_split = False
+                state_dict = paddlemix_load(shard_file)
+
+                # Mistmatched keys contains tuples key/shape1/shape2 of weights in the checkpoint that have a shape not
+                # matching the weights in the model.
+                mismatched_keys += _find_mismatched_keys(
+                    state_dict,
+                    model_state_dict,
+                    loaded_state_dict_keys,
+                    add_prefix_to_model,
+                    remove_prefix_from_model,
+                    ignore_mismatched_sizes,
+                )
+
+                if (
+                    self.config.tensor_parallel_degree > 1
+                    and ".tp" not in shard_file
+                    and not pre_tensor_parallel_split
+                ):
+                    logger.info("Converting state_dict to Tensor Parallel Format")
+                    # ignore error for multi shard, since only parts of data
+                    state_dict = self.convert_tensor_parallel(
+                        None, self.config, state_dict=state_dict, ignore_error=len(resolved_archive_file) > 1
+                    )
+                    logger.info("Converted state_dict to Tensor Parallel Format")
+
+                if low_cpu_mem_usage:
+                    new_error_msgs = _load_state_dict_into_meta_model(
+                        model_to_load,
+                        state_dict,
+                        loaded_state_dict_keys,
+                        start_prefix,
+                        expected_keys,
+                        dtype=dtype,
+                        is_safetensors=is_safetensors,
+                        keep_in_fp32_modules=keep_in_fp32_modules,
+                    )
+                    error_msgs += new_error_msgs
+                else:
+                    error_msgs += _load_state_dict_into_model(model_to_load, state_dict, start_prefix)
+
+                # force memory release
+                del state_dict
+                gc.collect()
+
+        if len(error_msgs) > 0:
+            error_msg = "\n\t".join(error_msgs)
+            if " but the expected shape is" in error_msg:
+                error_msg += (
+                    "\n\tYou may consider adding `ignore_mismatched_sizes=True` in the model `from_pretrained` method."
+                )
+            raise RuntimeError(f"Error(s) in loading state_dict for {self.__class__.__name__}:\n\t{error_msg}")
+
+        if len(unexpected_keys) > 0:
+            logger.warning(
+                f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
+                f" initializing {self.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
+                f" initializing {self.__class__.__name__} from the checkpoint of a model trained on another task or"
+                " with another architecture (e.g. initializing a BertForSequenceClassification model from a"
+                " BertForPreTraining model).\n- This IS NOT expected if you are initializing"
+                f" {self.__class__.__name__} from the checkpoint of a model that you expect to be exactly identical"
+                " (initializing a BertForSequenceClassification model from a BertForSequenceClassification model)."
+            )
+        else:
+            logger.info(f"All model checkpoint weights were used when initializing {self.__class__.__name__}.\n")
+
+        if len(missing_keys) > 0:
+            logger.warning(
+                f"Some weights of {self.__class__.__name__} were not initialized from the model checkpoint at"
+                f" {pretrained_model_name_or_path} and are newly initialized: {missing_keys}\nYou should probably"
+                " TRAIN this model on a down-stream task to be able to use it for predictions and inference."
+            )
+        elif len(mismatched_keys) == 0:
+            logger.info(
+                f"All the weights of {self.__class__.__name__} were initialized from the model checkpoint at"
+                f" {pretrained_model_name_or_path}.\nIf your task is similar to the task the model of the checkpoint"
+                f" was trained on, you can already use {self.__class__.__name__} for predictions without further"
+                " training."
+            )
+        if len(mismatched_keys) > 0:
+            mismatched_warning = "\n".join(
+                [
+                    f"- {key}: found shape {shape1} in the checkpoint and {shape2} in the model instantiated"
+                    for key, shape1, shape2 in mismatched_keys
+                ]
+            )
+            logger.warning(
+                f"Some weights of {self.__class__.__name__} were not initialized from the model checkpoint at"
+                f" {pretrained_model_name_or_path} and are newly initialized because the shapes did not"
+                f" match:\n{mismatched_warning}\nYou should probably TRAIN this model on a down-stream task to be able"
+                " to use it for predictions and inference."
+            )
+
+        return missing_keys, unexpected_keys, mismatched_keys

--- a/paddlemix/models/model_utils.py
+++ b/paddlemix/models/model_utils.py
@@ -27,6 +27,8 @@ from paddlemix.utils import device_guard, paddlemix_load
 from paddlemix.utils.env import MODEL_HOME
 from paddlemix.utils.log import logger
 
+__all__ = ["MixPretrainedModel"]
+
 
 def resolve_cache_dir(pretrained_model_name_or_path: str, cache_dir: Optional[str] = None) -> str:
     """resolve cache dir for PretrainedModel and PretrainedConfig
@@ -164,7 +166,8 @@ class MixPretrainedModel(PretrainedModel):
 
     The most difference between `PretrainedModel` and `MixPretrainedModel` is that
     `MixPretrainedModel` increaces `load_pretrained` method to support loading pretrained weights
-    in differenet stages after construction.
+    in differenet stages after construction. The other methods are the same as class
+    `paddlenlp.transformers.model_utils.PretrainedModel`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/paddlemix/models/model_utils.py
+++ b/paddlemix/models/model_utils.py
@@ -157,6 +157,16 @@ def _load_state_dict_into_meta_model(
 
 
 class MixPretrainedModel(PretrainedModel):
+    """
+    The base class for all pretrained models used in PaddleMIX. It mainly provides common methods
+    for loading (construction and loading) and saving pretrained models. Loading can be
+    customized in loaded_pretrained when the pretrained model is used for different stages.
+
+    The most difference between `PretrainedModel` and `MixPretrainedModel` is that
+    `MixPretrainedModel` increaces `load_pretrained` method to support loading pretrained weights
+    in differenet stages after construction.
+    """
+
     def __init__(self, *args, **kwargs):
         super(MixPretrainedModel, self).__init__(*args, **kwargs)
 
@@ -183,13 +193,20 @@ class MixPretrainedModel(PretrainedModel):
     ) -> Tuple[List[str]]:
         """load the state_dict into model, and do the following things:
 
-            * check the
+            * resolve the pretrained model name or path by checking if they exist in the cache and then
+            download them.
+            * load the pretrained model and refine the state dict if necessary.
+            * filter the weight keys and set the state_dict to the model.
 
         Args:
-            model (PretrainedModel): the pretrained model instance
-            state_dict (Dict[str, Tensor]): the model state dict data
+            pretrained_model_name_or_path (str): the pretrained model name or path.
+            state_dict (Dict[str, Tensor]): the model state dict data.
             ignore_mismatched_sizes (bool, optional): whether ignore error when tensor size mismatched. Defaults to False.
+            low_cpu_mem_usage (bool, optional): whether use low cpu memory usage for loading pretrained model。 Defautls to False.
             dtype (_type_, optional): the dtype of model state dict. Defaults to None.
+            cahce_cache_dir (str, optional): the cache directory for loading pretrained model. Defaults to None.
+            sufolder (str, optional): the subfolder of pretrained model name. Defaults "".
+            variant (str, optional): the pretrained model variant. Defaults to None.
 
         Returns:
             Tuple[List[str]]: _description_
@@ -211,7 +228,6 @@ class MixPretrainedModel(PretrainedModel):
             variant=variant,
         )
 
-        # load pt weights early so that we know which dtype to init the model under
         if not is_sharded and state_dict is None:
             # Time to load the checkpoint
             # loading non-sharded ckpt from the state dict

--- a/paddlemix/models/sam/modeling.py
+++ b/paddlemix/models/sam/modeling.py
@@ -17,7 +17,9 @@ from typing import Any, Dict, List
 
 import numpy as np
 import paddle
-from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
+from paddlenlp.transformers.model_utils import register_base_model
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 from .configuration import SamConfig
 from .image_encoder import ImageEncoderViT
@@ -31,7 +33,7 @@ __all__ = [
 ]
 
 
-class SamPretrainedModel(PretrainedModel):
+class SamPretrainedModel(MixPretrainedModel):
     """
     See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
     """

--- a/paddlemix/models/visualglm/modeling.py
+++ b/paddlemix/models/visualglm/modeling.py
@@ -31,11 +31,12 @@ from paddlenlp.transformers.model_outputs import (
     ModelOutput,
 )
 from paddlenlp.transformers.model_utils import (
-    PretrainedModel,
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
     prune_linear_layer,
 )
+
+from paddlemix.models.model_utils import MixPretrainedModel
 
 from ...activations import ACT2FN
 from ...utils.initializer import normal_, ones_, zeros_
@@ -98,7 +99,7 @@ class VisualGLMForConditionalGenerationModelOutput(ModelOutput):
         )
 
 
-class VisualGLMPretrainedModel(PretrainedModel):
+class VisualGLMPretrainedModel(MixPretrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
     models.

--- a/paddlemix/utils/__init__.py
+++ b/paddlemix/utils/__init__.py
@@ -11,3 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import contextlib
+
+import paddle
+
+
+@contextlib.contextmanager
+def device_guard(device="cpu", dev_id=0):
+    origin_device = paddle.device.get_device()
+    if device == "cpu":
+        paddle.set_device(device)
+    elif device in ["gpu", "xpu", "npu"]:
+        paddle.set_device("{}:{}".format(device, dev_id))
+    try:
+        yield
+    finally:
+        paddle.set_device(origin_device)
+
+
+def paddlemix_load(path, map_location="cpu"):
+    assert map_location in ["cpu", "gpu", "xpu", "npu", "numpy", "np"]
+    if map_location in ["numpy", "np"]:
+        return paddle.load(path, return_numpy=True)
+    else:
+        with device_guard(map_location):
+            return paddle.load(path)


### PR DESCRIPTION
1. add MixPretrainedModel as base model in PaddleMIX
2. MixPretrainedModel uses load_pretrained interface to support flexible load method in MLLM
    - add get_expect_keys to allow customize load
    - add refine_state_dict to allow update weight such as interpolation
3. unify the usage in pretrained stage:
```python
blip2_config = Blip2Config.from_pretrained('paddlemix/blip2-caption-opt2.7b')
model = Blip2ForConditionalGeneration(blip2_config)
model.load_pretrained('paddlemix/blip2-caption-opt2.7b')
```