### PR TITLE
optimize clip_by_norm

### DIFF
--- a/paddlemix/trainer/trainer.py
+++ b/paddlemix/trainer/trainer.py
@@ -76,7 +76,7 @@ class CLIPTrainer(Trainer):
             loss.backward()
 
         if self.args.max_grad_norm > 0.0:
-            grad_norms = clip_grad_norm(model, self.args.max_grad_norm)
+            grad_norms = clip_grad_norm(model, self.args.max_grad_norm, need_grad_norm=self.args.tensorboard)
         if self.rank == 0 and self.args.tensorboard:
             self.writer.add_scalar("train/loss", loss.item(), self.logstep)
             self.writer.add_scalar("train/lr", self.optimizer.get_lr(), self.logstep)


### PR DESCRIPTION
优化点：
- mul + set_value，其中set_value导致大量的memcpy，替换成inplace的操作
- 冗余的clip_norm计算，增加need_grad_norm，仅在tensorboard需要观察该值时再进行计算，否则会引入大量的norm算子
- 冗余的cast，PR代码中的 paddle_dtype打印结果为“float32”，但是实际tensor.dtype得到的是paddle.float32，会导致判断失败，从而引入无意义的cast。另外O2下梯度为fp16，原始写法需要每次将clip_coef_clamped转换成fp16，实际只需要计算一次，其他的梯度直接使用即可，所以添加了clip_coef_clamped_low_precison 变量。

效果：
- O1：0.739  steps/s -> 2.194 steps/s
- O2：1.067 steps/s -> 2.655 steps/s