### PR TITLE
【PPDiffusers】修复ddim系列int类型的timestep数据类型转换导致的bug

### DIFF
--- a/ppdiffusers/ppdiffusers/pipelines/fastdeploy_utils.py
+++ b/ppdiffusers/ppdiffusers/pipelines/fastdeploy_utils.py
@@ -568,13 +568,13 @@ class FastDeployDiffusionPipelineMixin:
 
     def get_timesteps(self, num_inference_steps, strength=1.0):
         if strength >= 1:
-            return self.scheduler.timesteps.cast(self.dtype), num_inference_steps
+            return self.scheduler.timesteps, num_inference_steps
 
         # get the original timestep using init_timestep
         init_timestep = min(int(num_inference_steps * strength), num_inference_steps)
 
         t_start = max(num_inference_steps - init_timestep, 0)
-        timesteps = self.scheduler.timesteps[t_start * self.scheduler.order :].cast(self.dtype)
+        timesteps = self.scheduler.timesteps[t_start * self.scheduler.order :]
 
         if hasattr(self.scheduler, "step_index_offset"):
             self.scheduler.step_index_offset = t_start * self.scheduler.order
@@ -1183,8 +1183,7 @@ class FastDeployRuntimeModel:
                 output,
             ]
         elif infer_op == "raw":
-            inputs = {}
-            for k, v in kwargs.items():
+            for k, v in inputs.items():
                 if paddle.is_tensor(v):
                     v = v.numpy()
                 inputs[k] = np.array(v)


### PR DESCRIPTION
修复这个错误，因为我们错误转换了数据类型导致，index索引时候报错了。
![f00637070fc8102f61f25bece2702387](https://github.com/PaddlePaddle/PaddleMIX/assets/50394665/7f1ee44d-3e5d-4174-8e40-a8f4da550865)
