### PR TITLE
【benchmark】update mem from B to MB

### DIFF
--- a/paddlemix/trainer/blip2_trainer.py
+++ b/paddlemix/trainer/blip2_trainer.py
@@ -131,8 +131,12 @@ class BenchmarkCallback(TrainerCallback):
                 max_mem_reserved_msg = ""
                 max_mem_allocated_msg = ""
                 if paddle.device.is_compiled_with_cuda():
-                    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B,"
-                    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
+                    max_mem_reserved_msg = (
+                        f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved() // (1024 ** 2)} MB,"
+                    )
+                    max_mem_allocated_msg = (
+                        f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated() // (1024 ** 2)} MB"
+                    )
                 logger.info(
                     "global step %d / %d, loss: %f, avg_reader_cost: %.5f sec, avg_batch_cost: %.5f sec, avg_samples: %.5f, ips: %.5f sample/sec, %s %s"
                     % (

--- a/ppdiffusers/examples/stable_diffusion/sd/sd_trainer.py
+++ b/ppdiffusers/examples/stable_diffusion/sd/sd_trainer.py
@@ -209,8 +209,12 @@ class BenchmarkCallback(TrainerCallback):
                 max_mem_reserved_msg = ""
                 max_mem_allocated_msg = ""
                 if paddle.device.is_compiled_with_cuda():
-                    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B,"
-                    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
+                    max_mem_reserved_msg = (
+                        f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved() // (1024 ** 2)} MB,"
+                    )
+                    max_mem_allocated_msg = (
+                        f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated() // (1024 ** 2)} MB"
+                    )
                 logger.info(
                     "global step %d / %d, loss: %f, avg_reader_cost: %.5f sec, avg_batch_cost: %.5f sec, avg_samples: %.5f, ips: %.5f sample/sec, %s %s"
                     % (

--- a/ppdiffusers/examples/text_to_image/train_text_to_image_lora_benchmark.py
+++ b/ppdiffusers/examples/text_to_image/train_text_to_image_lora_benchmark.py
@@ -1116,8 +1116,12 @@ def main():
                     max_mem_reserved_msg = ""
                     max_mem_allocated_msg = ""
                     if paddle.device.is_compiled_with_cuda():
-                        max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B,"
-                        max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
+                        max_mem_reserved_msg = (
+                            f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved() // (1024 ** 2)} MB,"
+                        )
+                        max_mem_allocated_msg = (
+                            f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated() // (1024 ** 2)} MB"
+                        )
 
                     logger.info(
                         "global step %d / %d, loss: %f, avg_reader_cost: %.5f sec, avg_batch_cost: %.5f sec, avg_samples: %.5f, ips: %.5f sample/sec, %s %s"


### PR DESCRIPTION
修改后日志信息为
[2023-12-05 19:18:10,207] [    INFO] - global step 95 / 22140, loss: 1.780640, avg_reader_cost: 0.00027 sec, avg_batch_cost: 0.67439 sec, avg_samples: 64.00000, ips: 94.90068 sample/sec, max_mem_reserved: 26397 MB, max_mem_allocated: 24184 MB