### PR TITLE
fix webui_stable_diffusion fp16 bug

### DIFF
--- a/ppdiffusers/examples/community/webui_stable_diffusion.py
+++ b/ppdiffusers/examples/community/webui_stable_diffusion.py
@@ -999,13 +999,13 @@ class WebUIStableDiffusionPipeline(DiffusionPipeline):
                     step = i // self.scheduler.order
                     do_batch = False
                     conds_list, cond_tensor = reconstruct_multicond_batch(prompt_embeds, step)
-                    cond_tensor = cond_tensor.to(self.unet.dtype)
+                    cond_tensor = cond_tensor.cast(self.unet.dtype)
                     try:
                         weight = conds_list[0][0][1]
                     except Exception:
                         weight = 1.0
                     if do_classifier_free_guidance:
-                        uncond_tensor = reconstruct_cond_batch(negative_prompt_embeds, step).to(self.unet.dtype)
+                        uncond_tensor = reconstruct_cond_batch(negative_prompt_embeds, step).cast(self.unet.dtype)
                         do_batch = cond_tensor.shape[1] == uncond_tensor.shape[1] and not isinstance(
                             self.controlnet, MultiControlNetModel
                         )

--- a/ppdiffusers/examples/community/webui_stable_diffusion.py
+++ b/ppdiffusers/examples/community/webui_stable_diffusion.py
@@ -999,12 +999,13 @@ class WebUIStableDiffusionPipeline(DiffusionPipeline):
                     step = i // self.scheduler.order
                     do_batch = False
                     conds_list, cond_tensor = reconstruct_multicond_batch(prompt_embeds, step)
+                    cond_tensor = cond_tensor.to(self.unet.dtype)
                     try:
                         weight = conds_list[0][0][1]
                     except Exception:
                         weight = 1.0
                     if do_classifier_free_guidance:
-                        uncond_tensor = reconstruct_cond_batch(negative_prompt_embeds, step)
+                        uncond_tensor = reconstruct_cond_batch(negative_prompt_embeds, step).to(self.unet.dtype)
                         do_batch = cond_tensor.shape[1] == uncond_tensor.shape[1] and not isinstance(
                             self.controlnet, MultiControlNetModel
                         )


### PR DESCRIPTION
解决使用fp16时出现的数据类型不匹配问题。

pipe = WebUIStableDiffusionPipeline.from_pretrained(
    "runwayml/stable-diffusion-v1-5", paddle_dtype=paddle.float16
)

具体错误信息如下：
ValueError: (InvalidArgument) The type of data we are trying to retrieve (float16) does not match the type of data (float32) currently contained in the container.
  [Hint: Expected dtype() == phi::CppTypeToDataType<T>::Type(), but received dtype():10 != phi::CppTypeToDataType<T>::Type():15.] (at /paddle/paddle/phi/core/[dense_tensor.cc:161](http://dense_tensor.cc:161/))
  [operator < linear > error]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/work/speed_up_framework/PaddleMIX/ppdiffusers/examples/community/webui_demo.py", line 27, in <module>
    img = pipe(
  File "/home/work/miniconda3/envs/paddle/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/work/miniconda3/envs/paddle/lib/python3.10/site-packages/paddle/base/dygraph/base.py", line 352, in _decorate_function
    return func(*args, **kwargs)
  File "/home/work/speed_up_framework/PaddleMIX/ppdiffusers/examples/community/webui_stable_diffusion.py", line 1121, in __call__
    raise ValueError(e)
ValueError: (InvalidArgument) The type of data we are trying to retrieve (float16) does not match the type of data (float32) currently contained in the container.
  [Hint: Expected dtype() == phi::CppTypeToDataType<T>::Type(), but received dtype():10 != phi::CppTypeToDataType<T>::Type():15.] (at /paddle/paddle/phi/core/[dense_tensor.cc:161](http://dense_tensor.cc:161/))
  [operator < linear > error]