### PR TITLE
[PPDiffusers] fix text2img to static

### DIFF
--- a/ppdiffusers/examples/text_to_image_laion400m/ldm/ldm_args.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/ldm/ldm_args.py
@@ -50,7 +50,6 @@ class ModelArguments:
     enable_xformers_memory_efficient_attention: bool = field(
         default=False, metadata={"help": "enable_xformers_memory_efficient_attention."}
     )
-    to_static: bool = field(default=False, metadata={"help": "Whether or not to_static"})
     prediction_type: Optional[str] = field(
         default="epsilon",
         metadata={

--- a/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_trainer.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_trainer.py
@@ -71,8 +71,8 @@ def main():
         interpolation="lanczos",
         tokenizer=model.tokenizer,
     )
-
-    if model_args.to_static:
+    # paddlenlp >= 2.7.0 `training_args`` has `to_static` attribute
+    if getattr(training_args, "to_static", False):
         input_ids = paddle.static.InputSpec(name="input_ids", shape=[-1, model_args.model_max_length], dtype="int64")
         pixel_values = paddle.static.InputSpec(
             name="pixel_values",


### PR DESCRIPTION
paddlenlp的2.7.1中，默认添加了to_static到trainingarguments里面了，会导致这里存在冲突。
正常用户是不会使用到 to_static 这个参数的。
![image](https://github.com/PaddlePaddle/PaddleMIX/assets/50394665/b3d42700-ee9f-4db3-9d9a-96f3896912e1)
