### PR TITLE
Avoid use stringified dtype in PIR mode

### DIFF
--- a/ppdiffusers/ppdiffusers/utils/paddle_utils.py
+++ b/ppdiffusers/ppdiffusers/utils/paddle_utils.py
@@ -204,8 +204,6 @@ if is_paddle_available():
 
         @contextmanager
         def dtype_guard(dtype="float32"):
-            if isinstance(dtype, paddle.dtype):
-                dtype = str(dtype).replace("paddle.", "")
             origin_dtype = paddle.get_default_dtype()
             paddle.set_default_dtype(dtype)
             try:


### PR DESCRIPTION
`paddle.set_default_dtype` 支持 `paddle.dtype`，不需要转换为字符串，而且在 PIR 模式下如果转换为字符串的话，目前还不是 `paddle.float32` 这种形式，我们不应该依赖于 `__str__/__repr__` 这种用于 debug 的信息