### PR TITLE
【FIX BUG】fix sdxl pipe load with from_single_file function

### DIFF
--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -886,7 +886,7 @@ textenc_conversion_map = {x[0]: x[1] for x in textenc_conversion_lst}
 
 textenc_transformer_conversion_lst = [
     # (stable-diffusion, HF Diffusers)
-    ("resblocks.", "text_model.model.layers."),
+    ("resblocks.", "text_model.encoder.layers."),
     ("ln_1", "layer_norm1"),
     ("ln_2", "layer_norm2"),
     (".c_fc.", ".fc1."),
@@ -1011,11 +1011,12 @@ def convert_open_clip_checkpoint(
     else:
         d_model = 1024
 
-    text_model_dict["text_model.embeddings.position_ids"] = text_model.text_model.embeddings.get_buffer("position_ids")
+    # text_model_dict["text_model.embeddings.position_embedding.weight"] = text_model.text_model.embeddings.get_buffer("position_ids")
 
     for key in keys:
         if key in keys_to_ignore:
             continue
+
         if key[len(prefix) :] in textenc_conversion_map:
             if key.endswith("text_projection"):
                 value = checkpoint[key].T
@@ -1045,8 +1046,7 @@ def convert_open_clip_checkpoint(
 
     if not (hasattr(text_model, "embeddings") and hasattr(text_model.embeddings.position_ids)):
         text_model_dict.pop("text_model.embeddings.position_ids", None)
-
-    faster_set_state_dict(text_model, convert_diffusers_vae_unet_to_ppdiffusers(text_model, text_model))
+    faster_set_state_dict(text_model, convert_diffusers_vae_unet_to_ppdiffusers(text_model, text_model_dict))
 
     return text_model
 

--- a/ppdiffusers/ppdiffusers/utils/load_utils.py
+++ b/ppdiffusers/ppdiffusers/utils/load_utils.py
@@ -311,9 +311,9 @@ def cast_to_paddle(tensor, return_numpy=False):
             tensor = tensor.reshape((1,))
         if "torch.bfloat16" in str(tensor.dtype):
             is_bfloat16 = True
-            tensor = tensor.float().cpu().numpy()
+            tensor = tensor.float().contiguous().cpu().numpy()
         else:
-            tensor = tensor.cpu().numpy()
+            tensor = tensor.contiguous().cpu().numpy()
         if return_numpy:
             return tensor
         if is_bfloat16:


### PR DESCRIPTION
test code：
```python
import paddle
from ppdiffusers import StableDiffusionXLPipeline
from ppdiffusers.transformers import CLIPTextModel, CLIPTextModelWithProjection

paddle.seed(0)
pipe_0 = StableDiffusionXLPipeline.from_single_file("/root/lxl/comfyui_env/ComfyUI/models/checkpoints/sdxl/人物写真_SDXL_Aisa.safetensors")

imag = pipe_0(prompt="1girl, blue hair", width=512, height=768, num_inference_steps=20, guidance_scale=5).images[0]
imag.save("./paddle_test_sdxl.png")
```