### PR TITLE
Use tensor in `window_reverse` to avoid precision issue

### DIFF
--- a/deploy/groundingdino/predict.py
+++ b/deploy/groundingdino/predict.py
@@ -123,7 +123,7 @@ def plot_boxes_to_image(image_pil, tgt):
     # draw boxes and masks
     for box, label in zip(boxes, labels):
         # from 0..1 to 0..W, 0..H
-        box = box * paddle.to_tensor([W, H, W, H])
+        box = box * paddle.to_tensor([W, H, W, H]).astype(paddle.float32)
         # from xywh to xyxy
         box[:2] -= box[2:] / 2
         box[2:] += box[:2]

--- a/paddlemix/examples/groundingdino/run_predict.py
+++ b/paddlemix/examples/groundingdino/run_predict.py
@@ -40,7 +40,7 @@ def plot_boxes_to_image(image_pil, tgt):
     # draw boxes and masks
     for box, label in zip(boxes, labels):
         # from 0..1 to 0..W, 0..H
-        box = box * paddle.to_tensor([W, H, W, H])
+        box = box * paddle.to_tensor([W, H, W, H]).astype(paddle.float32)
         # from xywh to xyxy
         box[:2] -= box[2:] / 2
         box[2:] += box[:2]

--- a/paddlemix/models/audioldm2/clap_module/htsat_model.py
+++ b/paddlemix/models/audioldm2/clap_module/htsat_model.py
@@ -214,7 +214,7 @@ def window_reverse(windows, window_size, H, W):
     Returns:
         x: (B, H, W, C)
     """
-    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size / window_size)))
+    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size * window_size)))
     x = windows.reshape([B, H // window_size, W // window_size, window_size, window_size, -1])
     x = x.transpose([0, 1, 3, 2, 4, 5]).reshape([B, H, W, -1])
     return x

--- a/paddlemix/models/audioldm2/clap_module/htsat_model.py
+++ b/paddlemix/models/audioldm2/clap_module/htsat_model.py
@@ -214,7 +214,7 @@ def window_reverse(windows, window_size, H, W):
     Returns:
         x: (B, H, W, C)
     """
-    B = int(windows.shape[0] / (H * W / window_size / window_size))
+    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size / window_size)))
     x = windows.reshape([B, H // window_size, W // window_size, window_size, window_size, -1])
     x = x.transpose([0, 1, 3, 2, 4, 5]).reshape([B, H, W, -1])
     return x

--- a/paddlemix/models/groundingdino/backbone/swin_transformer.py
+++ b/paddlemix/models/groundingdino/backbone/swin_transformer.py
@@ -164,7 +164,7 @@ def window_reverse(windows, window_size, H, W):
     Returns:
         x: (B, H, W, C)
     """
-    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size / window_size)))
+    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size * window_size)))
     x = windows.reshape([B, H // window_size, W // window_size, window_size, window_size, -1])
     x = x.transpose([0, 1, 3, 2, 4, 5]).reshape([B, H, W, -1])
     return x

--- a/paddlemix/models/groundingdino/backbone/swin_transformer.py
+++ b/paddlemix/models/groundingdino/backbone/swin_transformer.py
@@ -164,7 +164,7 @@ def window_reverse(windows, window_size, H, W):
     Returns:
         x: (B, H, W, C)
     """
-    B = int(windows.shape[0] / (H * W / window_size / window_size))
+    B = int(windows.shape[0] / (H * W / paddle.to_tensor(window_size / window_size)))
     x = windows.reshape([B, H // window_size, W // window_size, window_size, window_size, -1])
     x = x.transpose([0, 1, 3, 2, 4, 5]).reshape([B, H, W, -1])
     return x


### PR DESCRIPTION
在 `window_reverse` 里将 `window_size` 转换为 Tensor，`windows.shape[0]`、`H`、`W` 在动转静下，因为是动态 shape，所以都是 Tensor，而 `window_size` 是 scalar，会触发 scale OP，`x / n` 会转为 `scale(x, 1/n)`，这会导致精度问题，进而导致计算结果出错

一个简单的复现样例：

```python
x = paddle.to_tensor(25)
y = paddle.to_tensor(35)
out = int(x / (y * y / 7 / 7))
# 0，但应该是 1
```

暂时避免触发 scale OP，将 `window_size` 转为 Tensor 以触发 `elementwise_div`，未来可以考虑加一个 `scale_div` OP，让 `x / n` 转为 `scale_div(x, n)` 以避免精度问题（等之后 @gouzil 有空试试？）

该问题一直存在，只是之前的类型提升是向左 cast 隐藏了这点而已，3.0-beta 改了类型提升机制暴露了这点

另外还修改了下 predict 脚本里因为类型提升机制修改挂掉的问题，加了手动 cast