### PR TITLE
[fix bug in triton ops]

### DIFF
--- a/paddlemix/triton_ops/triton_ops.py
+++ b/paddlemix/triton_ops/triton_ops.py
@@ -865,9 +865,9 @@ def fused_adaLN_scale_residual(
             shift_mlp,
             resi_out,
             adaLN_out,
-            M,
+            -1,  # M
             N,
-            seq_size,
+            -1,  # seq_size
             epsilon,
             N_npo2=N_npo2,
             weight_attr=weight_attr,
@@ -1096,9 +1096,9 @@ def adaptive_layer_norm(x, scale, shift, weight=None, bias=None, epsilon=1e-05):
             y,
             y,
             y,
-            M,
+            -1,  # M
             N,
-            seq_size,
+            -1,  # seq_size,
             epsilon,
             BLOCK_SIZE=BLOCK_SIZE,
             weight_attr=weight_attr,


### PR DESCRIPTION
-1 表示这个值对于编译kernel没有帮助，因此将其设置为-1
