### PR TITLE
Fix environment initialization error in benchmark

### DIFF
--- a/tests/test_tipc/dygraph/dp/blip2/benchmark_common/prepare.sh
+++ b/tests/test_tipc/dygraph/dp/blip2/benchmark_common/prepare.sh
@@ -23,10 +23,10 @@ python -m pip install einops -i https://mirror.baidu.com/pypi/simple
 python -m pip install -r ../requirements.txt
 python -m pip install -e ../
 python -m pip install --upgrade paddlenlp pybind11 regex sentencepiece tqdm visualdl attrdict easydict pyyaml -i https://mirror.baidu.com/pypi/simple
-python -m pip install huggingface-hub==0.22.2 -i https://mirror.baidu.com/pypi/simple
 pip install -r ../paddlemix/appflow/requirements.txt
 pip install -U ppdiffusers
 python -m pip install ../../paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
 python -m pip install paddlenlp==3.0.0b0
+python -m pip install huggingface_hub==0.23.0
 python -m pip list
 cd -

--- a/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/prepare.sh
+++ b/tests/test_tipc/dygraph/dp/stable_diffusion/benchmark_common/prepare.sh
@@ -35,8 +35,8 @@ python -m pip install --upgrade pip -i https://mirror.baidu.com/pypi/simple
 python -m pip install einops -i https://mirror.baidu.com/pypi/simple
 python -m pip install -r ../requirements.txt
 python -m pip install --upgrade pybind11 regex sentencepiece tqdm visualdl attrdict easydict pyyaml paddlesde -i https://mirror.baidu.com/pypi/simple
-python -m pip install huggingface-hub==0.22.2 -i https://mirror.baidu.com/pypi/simple
 python -m pip install paddlenlp
+python -m pip install huggingface-hub==0.23.0
 
 # uninstall ppdiffusers and install develop paddlemix
 python -m pip uninstall -y ppdiffusers


### PR DESCRIPTION
修复benchmark任务初始化中由于安装huggingface_hub版本导致的任务报错，具体报错如下：
<img width="930" alt="b745ab7fe5aaeb86e56e08ab8b3abd8f" src="https://github.com/user-attachments/assets/c20770ac-bebb-4472-b412-75c1541ead0b">
