### PR TITLE
Allow use xformers memory effeicient attention in dy2st for Stable Diffusion

### DIFF
--- a/ppdiffusers/examples/stable_diffusion/sd/sd_args.py
+++ b/ppdiffusers/examples/stable_diffusion/sd/sd_args.py
@@ -92,7 +92,6 @@ class SDTrainingArguments(TrainingArguments):
 
         if self.to_static:
             self.use_ema = False
-            self.enable_xformers_memory_efficient_attention = False
             self.recompute = False
 
 


### PR DESCRIPTION
之前可能是因为动转静跑不通，SD 针对动转静情况关闭了 `enable_xformers_memory_efficient_attention`，但这会导致性能有所下降

经过测试，目前动转静开启 `enable_xformers_memory_efficient_attention` 是可以跑通的，且性能会提升，因此尝试删掉该设置