### PR TITLE
[Bugfix] Triton hotfix

### DIFF
--- a/paddlemix/triton_ops/rms_norm.py
+++ b/paddlemix/triton_ops/rms_norm.py
@@ -70,6 +70,7 @@ def rms_norm(x, weight=None, bias=None, epsilon=1e-5):
     import os
     os.environ["CUDA_VISIBLE_DEVICES"] = "2"
     import paddle
+    import paddlemix
 
     batch = 2
     seq = 3600

--- a/paddlemix/triton_ops/rms_norm.py
+++ b/paddlemix/triton_ops/rms_norm.py
@@ -125,12 +125,14 @@ def rms_norm(x, weight=None, bias=None, epsilon=1e-5):
         y = paddle.empty_like(x)
         prepare_ptr_for_triton_kernel = """
         auto y = paddle::empty(x.shape(), x.dtype(), x.place());
-        auto x_ptr = get_tensor_ptr(x);
-        auto y_ptr = get_tensor_ptr(y);
-        CUdeviceptr weight_ptr = (CUdeviceptr)(nullptr);
-        if (weight) weight_ptr = get_tensor_ptr(*weight);
-        CUdeviceptr bias_ptr = (CUdeviceptr)(nullptr);
-        if (bias) bias_ptr = get_tensor_ptr(*bias);
+        CUdeviceptr input_ptrs[4] = {
+            get_tensor_ptr(x),
+            get_tensor_ptr(y),
+            (CUdeviceptr)(nullptr),
+            (CUdeviceptr)(nullptr)
+        };
+        if (weight) input_ptrs[2] = get_tensor_ptr(*weight);
+        if (bias) input_ptrs[3] = get_tensor_ptr(*bias);
         """
         return_tensor_names = "y"
 

--- a/paddlemix/triton_ops/wint8.py
+++ b/paddlemix/triton_ops/wint8.py
@@ -333,12 +333,14 @@ def weight_only_int8(x, qweight, scales, bias=None, bool_trans_w=True):
 
         prepare_ptr_for_triton_kernel = """
         auto output = paddle::full({M,N}, 0, x.dtype(), x.place());
-        auto a_ptr = get_tensor_ptr(x);
-        auto b_ptr = get_tensor_ptr(qweight);
-        auto c_ptr = get_tensor_ptr(output);
-        auto bs_ptr = get_tensor_ptr(scales);
-        CUdeviceptr bias_ptr = (CUdeviceptr)(nullptr);
-        if (bias) bias_ptr = get_tensor_ptr(*bias);
+        CUdeviceptr input_ptrs[5] = {
+            get_tensor_ptr(x),
+            get_tensor_ptr(qweight),
+            get_tensor_ptr(output),
+            get_tensor_ptr(scales),
+            (CUdeviceptr)(nullptr)
+        };
+        if (bias) input_ptrs[4] = get_tensor_ptr(*bias);
         """
 
         return_tensor_names = "output"

--- a/paddlemix/triton_ops/wint8.py
+++ b/paddlemix/triton_ops/wint8.py
@@ -333,6 +333,7 @@ def weight_only_int8(x, qweight, scales, bias=None, bool_trans_w=True):
 
         prepare_ptr_for_triton_kernel = """
         auto output = paddle::full({M,N}, 0, x.dtype(), x.place());
+        auto c_ptr = get_tensor_ptr(output);
         CUdeviceptr input_ptrs[5] = {
             get_tensor_ptr(x),
             get_tensor_ptr(qweight),


### PR DESCRIPTION
# Introduction
As we have merged the sage attention triton PR, the `triton_utils.py` file has been modified, and during inference the triton kernel compilation throw error:

```bash
/d_workspace/PaddleMIX/ppdiffusers/deploy/sd3/tmp/sd3/forward/triton_fused_adaLN_scale_residual_fp16_2048_0_0/triton_fused_adaLN_scale_residual_fp16_2048_0_0.cu(59): error: identifier "input_ptrs" is undefined
                                                 input_ptrs[0],input_ptrs[1],input_ptrs[2],input_ptrs[3],input_ptrs[4],input_ptrs[5],input_ptrs[6],input_ptrs[7],input_ptrs[8],M,N,seq_size,epsilon,
                                                 ^
```

This PR mainly fix the following kernels' `prepare_ptr_for_triton_kernel` variable:

+ triton_fused_adaLN_scale_residual
+ triton_adaptive_layer_norm
+ split_concat

in `triton_ops.py` file.

+ rms_norm

in `rms_norm.py` file

+ weight_only_int8

in `wint8.py` file.

Now we may inference SD3 smoothly.