### PR TITLE
fix build_env.sh

### DIFF
--- a/build_env.sh
+++ b/build_env.sh
@@ -21,16 +21,16 @@ echo "开始安装 PaddleMIX 及其依赖..."
 
 # 安装 PaddleMIX
 echo "安装 PaddleMIX..."
-pip install -e . --user
+pip install -e .
 
 # 安装 ppdiffusers
 echo "安装 ppdiffusers..."
 cd ppdiffusers
-pip install -e . --user
+pip install -e .
 cd ..
 #注：ppdiffusers部分模型需要依赖 CUDA 11.2 及以上版本，如果本地机器不符合要求，建议前往 [AI Studio](https://aistudio.baidu.com/index) 进行模型训练、推理任务。
 #如果希望使用**bf16**训练推理，请使用支持**bf16**的GPU，如A100。
 
 # 安装依赖包
 echo "安装依赖包..."
-pip install -r requirements.txt --user
+pip install -r requirements.txt


### PR DESCRIPTION
--user会将安装的package放到/root/.local/lib/python3.xx/site-packages/，导致环境隔离失败。