### PR TITLE
[Experimental] Apply SOT to qwen25 vision forward

### DIFF
--- a/deploy/qwen2_5_vl/qwen2_5_vl_infer.py
+++ b/deploy/qwen2_5_vl/qwen2_5_vl_infer.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import paddle
+from paddle.base import core
 from paddle.distributed import fleet
 from paddlenlp.generation import GenerationConfig
 from paddlenlp.trainer import PdArgumentParser
@@ -179,8 +180,12 @@ def run_model(predictor_args):
     )
     input_tokens_len = vision_model_inputs.input_ids.shape[1]
     with paddle.no_grad():
+        core.nvprof_nvtx_push("vision_forward")
         inputs_embeds = vl_model.vision_forward(**vision_model_inputs)
+        core.nvprof_nvtx_pop()
+    core.nvprof_nvtx_push("init_llm_model_inputs")
     llm_model_inputs = init_llm_model_inputs(vision_model_inputs, inputs_embeds, arg_config=predictor_args)
+    core.nvprof_nvtx_pop()
     generated_text = ""
     generated_ids = paddle.to_tensor([], dtype="int64").reshape([1, 0])
     while llm_model_inputs["not_need_stop"]:
@@ -302,29 +307,30 @@ if predictor_args.benchmark:
     sumtime = 0.0
     times = repeat_times + warm_up
     for i in range(times):
-        if i > 2:
-            paddle.device.synchronize()
-            starttime = datetime.datetime.now()
-        generated_text = run_model(predictor_args)
+        with paddle.profiler.utils._nvprof_range(i, 5, 10):
+            if i > 2:
+                paddle.device.synchronize()
+                starttime = datetime.datetime.now()
+            generated_text = run_model(predictor_args)
 
-        # NOTE: (changwenbin) We delete some weights of the original dynamic graph,
-        # after fast_llm_model is converted to a static graph to reduce memory usage.
-        if (fast_llm_model.qwen2.transformer_block is not None) and (predictor_args.llm_mode == "static"):
-            fast_llm_model.qwen2.transformer_block = None
-            fast_llm_model.qwen2.norm = None
-            fast_llm_model.lm_head = None
-            paddle.device.cuda.empty_cache()
+            # NOTE: (changwenbin) We delete some weights of the original dynamic graph,
+            # after fast_llm_model is converted to a static graph to reduce memory usage.
+            if (fast_llm_model.qwen2.transformer_block is not None) and (predictor_args.llm_mode == "static"):
+                fast_llm_model.qwen2.transformer_block = None
+                fast_llm_model.qwen2.norm = None
+                fast_llm_model.lm_head = None
+                paddle.device.cuda.empty_cache()
 
-        if i > 2:
-            paddle.device.synchronize()
-            endtime = datetime.datetime.now()
-            print("Final output_text:\n", generated_text[0])
+            if i > 2:
+                paddle.device.synchronize()
+                endtime = datetime.datetime.now()
+                print("Final output_text:\n", generated_text[0])
 
-        if i > 2:
-            duringtime = endtime - starttime
-            duringtime = duringtime.seconds * 1000 + duringtime.microseconds / 1000.0
-            sumtime += duringtime
-            print(f"Single Image Inference: {predictor_args.model_name_or_path} end-to-end time : ", duringtime, "ms")
+            if i > 2:
+                duringtime = endtime - starttime
+                duringtime = duringtime.seconds * 1000 + duringtime.microseconds / 1000.0
+                sumtime += duringtime
+                print(f"Single Image Inference: {predictor_args.model_name_or_path} end-to-end time : ", duringtime, "ms")
     print(
         f"Single Image Inference: {predictor_args.model_name_or_path} average end-to-end time : ",
         sumtime / repeat_times,

--- a/paddlemix/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/paddlemix/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -29,6 +29,9 @@ from paddlenlp.transformers.configuration_utils import PretrainedConfig
 from paddlenlp.transformers.linear_utils import Linear
 from paddlenlp.transformers.model_outputs import BaseModelOutputWithPast, ModelOutput
 from paddlenlp.transformers.model_utils import PretrainedModel
+from paddlenlp.experimental.transformers.qwen2.modeling import (
+    Qwen2_5_VLForConditionalGenerationBlockInferenceModel,
+)
 
 from paddlemix.models.flash_attn_utils import has_flash_attn_func
 from paddlemix.models.qwen2_vl.bert_padding import (
@@ -682,9 +685,10 @@ class Qwen2RMSNorm(nn.Layer):
 
     def forward(self, hidden_states):
         if paddle.in_dynamic_mode():
-            with paddle.amp.auto_cast(False):
-                variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
-                hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+            # NOTE(SigureMo): Temporarily disable auto_cast to avoid break graph in SOT
+            # with paddle.amp.auto_cast(False):
+            variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
+            hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
         else:
             variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
             hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
@@ -2044,6 +2048,7 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel):
         return model_kwargs
 
     # NOTE（changwenbin）: Vision module added for high-performance inference.
+    @paddle.jit.to_static
     def vision_forward(
         self,
         input_ids: paddle.Tensor,
@@ -2061,9 +2066,6 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel):
         if inputs_embeds is None:
             # NOTE: (zhoukangkang、changwenbin) In the high-performance reasoning of Qwen2-vl,
             # in order to reduce video memory, the qwen2 embed_tokens method in Paddlenlp is reused here.
-            from paddlenlp.experimental.transformers.qwen2.modeling import (
-                Qwen2_5_VLForConditionalGenerationBlockInferenceModel,
-            )
 
             assert isinstance(
                 self.model, Qwen2_5_VLForConditionalGenerationBlockInferenceModel


### PR DESCRIPTION
实验性转静分支，使用编译器优化 qwen 2.5 vision forward

预期图结构：

<img width="932" alt="image" src="https://github.com/user-attachments/assets/904526d7-f67b-4b86-8624-67f095693ce5" />
