### PR TITLE
remove aistudio version

### DIFF
--- a/ppdiffusers/requirements.txt
+++ b/ppdiffusers/requirements.txt
@@ -18,4 +18,3 @@ huggingface_hub
 hf_transfer
 wandb
 imageio
-aistudio-sdk==0.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ referencing>=0.32.1
 decord>=0.6.0
 brisque
 av
-aistudio-sdk==0.2.6


### PR DESCRIPTION
PaddleNLP commit: https://github.com/PaddlePaddle/PaddleNLP/commit/c9c0a3ec9ea84a76a2ddbb112916e466ba6404d7 已合入 commit里面使用了aistudio sdk的新版本特性 与旧版本不兼容